### PR TITLE
cmd: adds cmd pkg

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -3,11 +3,16 @@ package cmd
 import (
 	"fmt"
 
-	"graphql-go/compatibility-base/bubbletea"
+	"github.com/graphql-go/compatibility-base/bubbletea"
 )
 
 // CLI represents the command line interface component.
 type CLI struct {
+}
+
+// New returns a pointer to the `CLI` struct.
+func New() *CLI {
+	return &CLI{}
 }
 
 // RunResult is the result of executing the run method.

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -25,13 +25,12 @@ func New(p *NewParams) *CLI {
 
 // RunResult is the result of executing the run method.
 type RunResult struct {
+	// Choice is the option chosen after running the CLI application.
 	Choice string
 }
 
 // RunParams are the parameters of the run method.
 type RunParams struct {
-	Choices []string
-	Header  string
 }
 
 // Run runs the CLI application and returns the result.

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -11,6 +11,7 @@ type CLI struct {
 	bubbletea *bubbletea.BubbleTea
 }
 
+// NewParams represents the parameters for the new method.
 type NewParams struct {
 	Bubbletea *bubbletea.BubbleTea
 }

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"graphql-go/compatibility-base/bubbletea"
+)
+
+// CLI represents the command line interface component.
+type CLI struct {
+}
+
+// RunResult is the result of executing the run method.
+type RunResult struct {
+	Choice string
+}
+
+// RunParams are the parameters of the run method.
+type RunParams struct {
+	Choices []string
+	Header  string
+}
+
+// Run runs the CLI application and returns the result.
+func (c *CLI) Run(p *RunParams) (*RunResult, error) {
+	bt := bubbletea.New(&bubbletea.Params{
+		Choices: p.Choices,
+		UI: bubbletea.UIParams{
+			Header: p.Header,
+		},
+	})
+
+	btRunResult, err := bt.Run()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run: %w", err)
+	}
+
+	return &RunResult{
+		Choice: btRunResult.Choice,
+	}, nil
+}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -8,11 +8,18 @@ import (
 
 // CLI represents the command line interface component.
 type CLI struct {
+	bubbletea *bubbletea.BubbleTea
+}
+
+type NewParams struct {
+	Bubbletea *bubbletea.BubbleTea
 }
 
 // New returns a pointer to the `CLI` struct.
-func New() *CLI {
-	return &CLI{}
+func New(p *NewParams) *CLI {
+	return &CLI{
+		bubbletea: p.Bubbletea,
+	}
 }
 
 // RunResult is the result of executing the run method.
@@ -28,14 +35,7 @@ type RunParams struct {
 
 // Run runs the CLI application and returns the result.
 func (c *CLI) Run(p *RunParams) (*RunResult, error) {
-	bt := bubbletea.New(&bubbletea.Params{
-		Choices: p.Choices,
-		UI: bubbletea.UIParams{
-			Header: p.Header,
-		},
-	})
-
-	btRunResult, err := bt.Run()
+	btRunResult, err := c.bubbletea.Run()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run: %w", err)
 	}


### PR DESCRIPTION
#### Details
- `cmd`: adds `New` method and parameterizes bubbletea dependency.
- `cmd`: adds `New` function.
- `cmd`: adds the cmd pkg.

#### Test Plan
- :heavy_check_mark: Tested via unit tests:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-base$ ./bin/test.sh 
ok  	github.com/graphql-go/compatibility-base/bubbletea	0.003s
?   	github.com/graphql-go/compatibility-base/cmd	[no test files]
ok  	github.com/graphql-go/compatibility-base/config	0.001s
?   	github.com/graphql-go/compatibility-base/implementation	[no test files]
ok  	github.com/graphql-go/compatibility-base/puller	0.004s
?   	github.com/graphql-go/compatibility-base/types	[no test files]
```