### PR TITLE
{bubbletea,main}: improves bubbletea pkg to support multiple models

### DIFF
--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -6,7 +6,37 @@ import (
 
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
+
+type BubbleTeaModel struct {
+	currentModel tea.Model
+	baseStyle    lipgloss.Style
+}
+
+func (b BubbleTeaModel) Init() tea.Cmd {
+	return nil
+}
+
+func (b BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return nil, nil
+}
+
+func (b BubbleTeaModel) View() string {
+	return b.baseStyle.Render(b.currentModel.View()) + "\n"
+}
+
+func NewBubbleTeaModel() *BubbleTeaModel {
+	var baseStyle = lipgloss.NewStyle().
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("240"))
+
+	b := &BubbleTeaModel{}
+
+	b.baseStyle = baseStyle
+
+	return b
+}
 
 // BubbleTea represents the CLI component that wraps the `bubbletea` library.
 type BubbleTea struct {

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -9,13 +9,19 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// Model represents the component that wraps the `bubbletea` Model interface.
+type Model interface {
+	tea.Model
+	Run(modelResult any) (any, error)
+}
+
 // BubbleTea represents the CLI component that wraps the `bubbletea` library.
 type BubbleTea struct {
 	// baseStyle is the base styling of the BubbleTea component.
 	baseStyle lipgloss.Style
 
 	// currentModel is the current model of the BubbleTea component.
-	currentModel tea.Model
+	currentModel Model
 }
 
 // Init is the `BubbleTea` method required for implementing the `Model` interface.
@@ -44,33 +50,21 @@ func (b BubbleTea) View() string {
 }
 
 // Run runs the `BubbleTea` component and returns its result.
-func (b BubbleTea) Run() (*RunResult, error) {
+func (b BubbleTea) Run() (any, error) {
 	teaProgram := tea.NewProgram(b)
 
-	_, err := teaProgram.Run()
+	m, err := teaProgram.Run()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run: %w", err)
 	}
 
-	result := &RunResult{}
-
-	// if m, ok := m.(BubbleTea); ok && m.choice != "" {
-	// 	result.Choice = m.choice
-	// }
-
-	return result, nil
-}
-
-// RunResult represents the result of the run method.
-type RunResult struct {
-	// Choice is the option chosen.
-	Choice string
+	return b.currentModel.Run(m)
 }
 
 // Params represents the parameters for the `NewBubbleTea` function.
 type Params struct {
 	// Model is the model parameter of the BubbleTea component.
-	Model tea.Model
+	Model Model
 }
 
 // NewBubbleTea returns a new BubbleTea struct instance.
@@ -174,6 +168,23 @@ func (b ChoicesModel) View() string {
 	s.WriteString(endingMessage)
 
 	return s.String()
+}
+
+// ChoicesModelResult represents the result of the run method.
+type ChoicesModelResult struct {
+	// Choice is the option chosen.
+	Choice string
+}
+
+// Run runs the `ChoicesModel` component and returns its result.
+func (b ChoicesModel) Run(model any) (any, error) {
+	result := &ChoicesModelResult{}
+
+	if model, ok := model.(ChoicesModel); ok && model.choice != "" {
+		result.Choice = model.choice
+	}
+
+	return result, nil
 }
 
 // ChoicesModelParams represents the parameters struct for the `NewChoicesModel` function.

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -179,6 +179,9 @@ func (b ChoicesModel) Run(model any) (any, error) {
 
 // ChoicesModelParams represents the parameters struct for the `NewChoicesModel` function.
 type ChoicesModelParams struct {
+	// Choice is the current CLI choice.
+	Choice string
+
 	// Choices is the slice of options available.
 	Choices []string
 
@@ -198,6 +201,7 @@ type ChoicesModelUIParams struct {
 // NewChoicesModel returns a pointer for the `ChoicesModel`.
 func NewChoicesModel(p *ChoicesModelParams) *ChoicesModel {
 	return &ChoicesModel{
+		choice:  p.Choice,
 		choices: p.Choices,
 		cursor:  p.Cursor,
 		ui: ChoicesModelUI{

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -9,37 +9,86 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-type BubbleTeaModel struct {
+// BubbleTea represents the CLI component that wraps the `bubbletea` library.
+type BubbleTea struct {
+	// baseStyle is the base styling of the BubbleTea component.
+	baseStyle lipgloss.Style
+
+	// currentModel is the current model of the BubbleTea component.
 	currentModel tea.Model
-	baseStyle    lipgloss.Style
 }
 
-func (b BubbleTeaModel) Init() tea.Cmd {
+// Init is the `BubbleTea` method required for implementing the `Model` interface.
+func (b BubbleTea) Init() tea.Cmd {
 	return nil
 }
 
-func (b BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	return nil, nil
+// Update is the `BubbleTea` method required for implementing the `Model` interface.
+func (b BubbleTea) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return b, nil
+	}
+
+	switch keyMsg.String() {
+	case "ctrl+c", "q", "esc":
+		return b, tea.Quit
+	}
+
+	return b, nil
 }
 
-func (b BubbleTeaModel) View() string {
+// View is the `BubbleTea` method required for implementing the `Model` interface.
+func (b BubbleTea) View() string {
 	return b.baseStyle.Render(b.currentModel.View()) + "\n"
 }
 
-func NewBubbleTeaModel() *BubbleTeaModel {
+// Run runs the `BubbleTea` component and returns its result.
+func (b BubbleTea) Run() (*RunResult, error) {
+	teaProgram := tea.NewProgram(b)
+
+	_, err := teaProgram.Run()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run: %w", err)
+	}
+
+	result := &RunResult{}
+
+	// if m, ok := m.(BubbleTea); ok && m.choice != "" {
+	// 	result.Choice = m.choice
+	// }
+
+	return result, nil
+}
+
+// RunResult represents the result of the run method.
+type RunResult struct {
+	// Choice is the option chosen.
+	Choice string
+}
+
+// Params represents the parameters for the `NewBubbleTea` function.
+type Params struct {
+	// Model is the model parameter of the BubbleTea component.
+	Model tea.Model
+}
+
+// NewBubbleTea returns a new BubbleTea struct instance.
+func New(p *Params) *BubbleTea {
 	var baseStyle = lipgloss.NewStyle().
 		BorderStyle(lipgloss.NormalBorder()).
 		BorderForeground(lipgloss.Color("240"))
 
-	b := &BubbleTeaModel{}
+	b := &BubbleTea{}
 
 	b.baseStyle = baseStyle
+	b.currentModel = p.Model
 
 	return b
 }
 
-// BubbleTea represents the CLI component that wraps the `bubbletea` library.
-type BubbleTea struct {
+// ChoicesModel represents the CLI component that wraps the `bubbletea` library.
+type ChoicesModel struct {
 	// cursor is the reference of the current CLI choice.
 	cursor int
 
@@ -50,26 +99,26 @@ type BubbleTea struct {
 	choices []string
 
 	// ui is the UI of the CLI.
-	ui UI
+	ui ChoicesModelUI
 
 	// table is the bubbletea table model.
 	// TODO(@chris-ramon): Make it available through multiple model support.
 	table table.Model
 }
 
-// UI represents the UI struct for the `BubbleTea` component.
-type UI struct {
+// ChoicesModelUI represents the UI struct for the `ChoicesModel` component.
+type ChoicesModelUI struct {
 	// header is the UI header text.
 	header string
 }
 
 // Init is the `BubbleTea` method required for implementing the `Model` interface.
-func (b BubbleTea) Init() tea.Cmd {
+func (b ChoicesModel) Init() tea.Cmd {
 	return nil
 }
 
 // Update is the `BubbleTea` method required for implementing the `Model` interface.
-func (b BubbleTea) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:golint,ireturn
+func (b ChoicesModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:golint,ireturn
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return b, nil
@@ -103,7 +152,7 @@ func (b BubbleTea) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:golint,ir
 }
 
 // View is the `BubbleTea` method required for implementing the `Model` interface.
-func (b BubbleTea) View() string {
+func (b ChoicesModel) View() string {
 	s := strings.Builder{}
 	s.WriteString(b.ui.header)
 	s.WriteString("")
@@ -127,14 +176,8 @@ func (b BubbleTea) View() string {
 	return s.String()
 }
 
-// RunResult represents the result of the run method.
-type RunResult struct {
-	// Choice is the option chosen.
-	Choice string
-}
-
-// Params represents the parameters struct for the new method.
-type Params struct {
+// ChoicesModelParams represents the parameters struct for the `NewChoicesModel` function.
+type ChoicesModelParams struct {
 	// Choices is the slice of options available.
 	Choices []string
 
@@ -142,40 +185,22 @@ type Params struct {
 	Cursor int
 
 	// UI is the user interface parameters.
-	UI UIParams
+	UI ChoicesModelUIParams
 }
 
-// UIParams represents the UI parameters for the new method parameters.
-type UIParams struct {
+// ChoicesModelUIParams represents the UI parameters for the `NewChoicesModel` function parameters.
+type ChoicesModelUIParams struct {
 	// Header is the UI header text.
 	Header string
 }
 
-// New returns a pointer for the `BubbleTea` component.
-func New(p *Params) *BubbleTea {
-	return &BubbleTea{
+// NewChoicesModel returns a pointer for the `ChoicesModel`.
+func NewChoicesModel(p *ChoicesModelParams) *ChoicesModel {
+	return &ChoicesModel{
 		choices: p.Choices,
 		cursor:  p.Cursor,
-		ui: UI{
+		ui: ChoicesModelUI{
 			header: p.UI.Header,
 		},
 	}
-}
-
-// Run runs the `BubbleTea` component and returns its result.
-func (b BubbleTea) Run() (*RunResult, error) {
-	teaProgram := tea.NewProgram(b)
-
-	m, err := teaProgram.Run()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run: %w", err)
-	}
-
-	result := &RunResult{}
-
-	if m, ok := m.(BubbleTea); ok && m.choice != "" {
-		result.Choice = m.choice
-	}
-
-	return result, nil
 }

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -26,22 +26,12 @@ type BubbleTea struct {
 
 // Init is the `BubbleTea` method required for implementing the `Model` interface.
 func (b BubbleTea) Init() tea.Cmd {
-	return nil
+	return b.currentModel.Init()
 }
 
 // Update is the `BubbleTea` method required for implementing the `Model` interface.
 func (b BubbleTea) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	keyMsg, ok := msg.(tea.KeyMsg)
-	if !ok {
-		return b, nil
-	}
-
-	switch keyMsg.String() {
-	case "ctrl+c", "q", "esc":
-		return b, tea.Quit
-	}
-
-	return b, nil
+	return b.currentModel.Update(msg)
 }
 
 // View is the `BubbleTea` method required for implementing the `Model` interface.

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -11,7 +11,10 @@ import (
 
 // Model represents the component that wraps the `bubbletea` Model interface.
 type Model interface {
+	// tea.Model is the base interface.
 	tea.Model
+
+	// Run runs and returns its result.
 	Run(modelResult any) (any, error)
 }
 

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -57,7 +57,7 @@ type Params struct {
 	Model Model
 }
 
-// NewBubbleTea returns a new BubbleTea struct instance.
+// New returns a new BubbleTea struct instance.
 func New(p *Params) *BubbleTea {
 	var baseStyle = lipgloss.NewStyle().
 		BorderStyle(lipgloss.NormalBorder()).

--- a/bubbletea/bubbletea_init_test.go
+++ b/bubbletea/bubbletea_init_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestBubbleTeaInit(t *testing.T) {
-	b := BubbleTea{}
+	b := New(&Params{
+		Model: &ChoicesModel{},
+	})
 
 	assert.Nil(t, b.Init(), "unexpected non-nil result")
 }

--- a/bubbletea/bubbletea_update_test.go
+++ b/bubbletea/bubbletea_update_test.go
@@ -14,7 +14,7 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		subTestName      string
 		initialBubbletea tea.Model
 		updateParams     tea.Msg
-		expectedModel    tea.Model
+		expectedModel    *ChoicesModel
 		expectedCmd      tea.Cmd
 	}{
 		{
@@ -23,7 +23,7 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Model: NewChoicesModel(&ChoicesModelParams{}),
 			}),
 			updateParams:  nil,
-			expectedModel: BubbleTea{},
+			expectedModel: NewChoicesModel(&ChoicesModelParams{}),
 			expectedCmd:   (tea.Cmd)(nil),
 		},
 		{
@@ -34,7 +34,7 @@ func TestBubbleTeaUpdate(t *testing.T) {
 			updateParams: tea.KeyMsg{
 				Type: tea.KeyCtrlC,
 			},
-			expectedModel: BubbleTea{},
+			expectedModel: NewChoicesModel(&ChoicesModelParams{}),
 			expectedCmd:   tea.Quit,
 		},
 		{
@@ -47,11 +47,11 @@ func TestBubbleTeaUpdate(t *testing.T) {
 			updateParams: tea.KeyMsg{
 				Type: tea.KeyEnter,
 			},
-			expectedModel: ChoicesModel{
-				cursor:  0,
-				choices: []string{"test-choice-0"},
-				choice:  "test-choice-0",
-			},
+			expectedModel: NewChoicesModel(&ChoicesModelParams{
+				Cursor:  0,
+				Choices: []string{"test-choice-0"},
+				Choice:  "test-choice-0",
+			}),
 			expectedCmd: tea.Quit,
 		},
 		{
@@ -65,10 +65,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Type:  tea.KeyRunes,
 				Runes: []rune("j"),
 			},
-			expectedModel: ChoicesModel{
-				cursor:  1,
-				choices: []string{"test-choice-0", "test-choice-1"},
-			},
+			expectedModel: NewChoicesModel(&ChoicesModelParams{
+				Cursor:  1,
+				Choices: []string{"test-choice-0", "test-choice-1"},
+			}),
 			expectedCmd: nil,
 		},
 		{
@@ -83,10 +83,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Type:  tea.KeyRunes,
 				Runes: []rune("j"),
 			},
-			expectedModel: ChoicesModel{
-				cursor:  0,
-				choices: []string{"test-choice-0", "test-choice-1"},
-			},
+			expectedModel: NewChoicesModel(&ChoicesModelParams{
+				Cursor:  0,
+				Choices: []string{"test-choice-0", "test-choice-1"},
+			}),
 			expectedCmd: nil,
 		},
 		{
@@ -101,10 +101,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Type:  tea.KeyRunes,
 				Runes: []rune("k"),
 			},
-			expectedModel: ChoicesModel{
-				cursor:  0,
-				choices: []string{"test-choice-0", "test-choice-1"},
-			},
+			expectedModel: NewChoicesModel(&ChoicesModelParams{
+				Cursor:  0,
+				Choices: []string{"test-choice-0", "test-choice-1"},
+			}),
 			expectedCmd: nil,
 		},
 		{
@@ -119,10 +119,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Type:  tea.KeyRunes,
 				Runes: []rune("k"),
 			},
-			expectedModel: ChoicesModel{
-				cursor:  0,
-				choices: []string{"test-choice-0"},
-			},
+			expectedModel: NewChoicesModel(&ChoicesModelParams{
+				Cursor:  0,
+				Choices: []string{"test-choice-0"},
+			}),
 			expectedCmd: nil,
 		},
 	}
@@ -131,7 +131,7 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		t.Run(tt.subTestName, func(t *testing.T) {
 			model, cmd := tt.initialBubbletea.Update(tt.updateParams)
 
-			assert.Equal(t, tt.expectedModel, model)
+			assert.Equal(t, *tt.expectedModel, model)
 			customAssert.AssertFunc(t, tt.expectedCmd, cmd)
 		})
 	}

--- a/bubbletea/bubbletea_update_test.go
+++ b/bubbletea/bubbletea_update_test.go
@@ -18,15 +18,19 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		expectedCmd      tea.Cmd
 	}{
 		{
-			subTestName:      "Handles invalid tea key message",
-			initialBubbletea: New(&Params{}),
-			updateParams:     nil,
-			expectedModel:    BubbleTea{},
-			expectedCmd:      (tea.Cmd)(nil),
+			subTestName: "Handles invalid tea key message",
+			initialBubbletea: New(&Params{
+				Model: NewChoicesModel(&ChoicesModelParams{}),
+			}),
+			updateParams:  nil,
+			expectedModel: BubbleTea{},
+			expectedCmd:   (tea.Cmd)(nil),
 		},
 		{
-			subTestName:      "Handles ctrl+c tea key message",
-			initialBubbletea: New(&Params{}),
+			subTestName: "Handles ctrl+c tea key message",
+			initialBubbletea: New(&Params{
+				Model: NewChoicesModel(&ChoicesModelParams{}),
+			}),
 			updateParams: tea.KeyMsg{
 				Type: tea.KeyCtrlC,
 			},
@@ -36,12 +40,14 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles enter tea key message",
 			initialBubbletea: New(&Params{
-				Choices: []string{"test-choice-0"},
+				Model: NewChoicesModel(&ChoicesModelParams{
+					Choices: []string{"test-choice-0"},
+				}),
 			}),
 			updateParams: tea.KeyMsg{
 				Type: tea.KeyEnter,
 			},
-			expectedModel: BubbleTea{
+			expectedModel: ChoicesModel{
 				cursor:  0,
 				choices: []string{"test-choice-0"},
 				choice:  "test-choice-0",
@@ -51,13 +57,15 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles down tea key message",
 			initialBubbletea: New(&Params{
-				Choices: []string{"test-choice-0", "test-choice-1"},
+				Model: NewChoicesModel(&ChoicesModelParams{
+					Choices: []string{"test-choice-0", "test-choice-1"},
+				}),
 			}),
 			updateParams: tea.KeyMsg{
 				Type:  tea.KeyRunes,
 				Runes: []rune("j"),
 			},
-			expectedModel: BubbleTea{
+			expectedModel: ChoicesModel{
 				cursor:  1,
 				choices: []string{"test-choice-0", "test-choice-1"},
 			},
@@ -66,14 +74,16 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles cursor reset for down tea key message",
 			initialBubbletea: New(&Params{
-				Cursor:  1,
-				Choices: []string{"test-choice-0", "test-choice-1"},
+				Model: NewChoicesModel(&ChoicesModelParams{
+					Cursor:  1,
+					Choices: []string{"test-choice-0", "test-choice-1"},
+				}),
 			}),
 			updateParams: tea.KeyMsg{
 				Type:  tea.KeyRunes,
 				Runes: []rune("j"),
 			},
-			expectedModel: BubbleTea{
+			expectedModel: ChoicesModel{
 				cursor:  0,
 				choices: []string{"test-choice-0", "test-choice-1"},
 			},
@@ -82,14 +92,16 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles up tea key message",
 			initialBubbletea: New(&Params{
-				Cursor:  1,
-				Choices: []string{"test-choice-0", "test-choice-1"},
+				Model: NewChoicesModel(&ChoicesModelParams{
+					Cursor:  1,
+					Choices: []string{"test-choice-0", "test-choice-1"},
+				}),
 			}),
 			updateParams: tea.KeyMsg{
 				Type:  tea.KeyRunes,
 				Runes: []rune("k"),
 			},
-			expectedModel: BubbleTea{
+			expectedModel: ChoicesModel{
 				cursor:  0,
 				choices: []string{"test-choice-0", "test-choice-1"},
 			},
@@ -98,14 +110,16 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles cursor reset for up tea key message",
 			initialBubbletea: New(&Params{
-				Cursor:  0,
-				Choices: []string{"test-choice-0"},
+				Model: NewChoicesModel(&ChoicesModelParams{
+					Cursor:  0,
+					Choices: []string{"test-choice-0"},
+				}),
 			}),
 			updateParams: tea.KeyMsg{
 				Type:  tea.KeyRunes,
 				Runes: []rune("k"),
 			},
-			expectedModel: BubbleTea{
+			expectedModel: ChoicesModel{
 				cursor:  0,
 				choices: []string{"test-choice-0"},
 			},

--- a/bubbletea/bubbletea_view_test.go
+++ b/bubbletea/bubbletea_view_test.go
@@ -23,11 +23,7 @@ func TestBubbleTeaView(t *testing.T) {
 					},
 				}),
 			}),
-			expectedView: `test-header: 
-(•) test-choice-0
-
-(press q to quit)
-`,
+			expectedView: "┌─────────────────┐\n│test-header:     │\n│(•) test-choice-0│\n│                 │\n│(press q to quit)│\n│                 │\n└─────────────────┘\n",
 		},
 		{
 			subTestName: "Handles success view result with multiple choices",
@@ -39,12 +35,7 @@ func TestBubbleTeaView(t *testing.T) {
 					},
 				}),
 			}),
-			expectedView: `test-header: 
-(•) test-choice-0
-( ) test-choice-1
-
-(press q to quit)
-`,
+			expectedView: "┌─────────────────┐\n│test-header:     │\n│(•) test-choice-0│\n│( ) test-choice-1│\n│                 │\n│(press q to quit)│\n│                 │\n└─────────────────┘\n",
 		},
 	}
 

--- a/bubbletea/bubbletea_view_test.go
+++ b/bubbletea/bubbletea_view_test.go
@@ -16,10 +16,12 @@ func TestBubbleTeaView(t *testing.T) {
 		{
 			subTestName: "Handles success view result",
 			initialBubbletea: New(&Params{
-				Choices: []string{"test-choice-0"},
-				UI: UIParams{
-					Header: "test-header: \n",
-				},
+				Model: NewChoicesModel(&ChoicesModelParams{
+					Choices: []string{"test-choice-0"},
+					UI: ChoicesModelUIParams{
+						Header: "test-header: \n",
+					},
+				}),
 			}),
 			expectedView: `test-header: 
 (•) test-choice-0
@@ -30,10 +32,12 @@ func TestBubbleTeaView(t *testing.T) {
 		{
 			subTestName: "Handles success view result with multiple choices",
 			initialBubbletea: New(&Params{
-				Choices: []string{"test-choice-0", "test-choice-1"},
-				UI: UIParams{
-					Header: "test-header: \n",
-				},
+				Model: NewChoicesModel(&ChoicesModelParams{
+					Choices: []string{"test-choice-0", "test-choice-1"},
+					UI: ChoicesModelUIParams{
+						Header: "test-header: \n",
+					},
+				}),
 			}),
 			expectedView: `test-header: 
 (•) test-choice-0

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/graphql-go/compatibility-base/bubbletea"
@@ -40,7 +41,12 @@ func (c *CLI) Run(p *RunParams) (*RunResult, error) {
 		return nil, fmt.Errorf("failed to run: %w", err)
 	}
 
+	r, ok := btRunResult.(*bubbletea.ChoicesModelResult)
+	if !ok {
+		return nil, errors.New("unexpected type")
+	}
+
 	return &RunResult{
-		Choice: btRunResult.Choice,
+		Choice: r.Choice,
 	}, nil
 }

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -9,11 +9,13 @@ import (
 
 // CLI represents the command line interface component.
 type CLI struct {
+	// bubbletea is the component that wraps the bubbletea library.
 	bubbletea *bubbletea.BubbleTea
 }
 
 // NewParams represents the parameters for the new method.
 type NewParams struct {
+	// Bubbletea is the component parameter that wraps the bubbletea library.
 	Bubbletea *bubbletea.BubbleTea
 }
 

--- a/main.go
+++ b/main.go
@@ -3,12 +3,24 @@ package main
 import (
 	"log"
 
+	"github.com/graphql-go/compatibility-base/bubbletea"
 	"github.com/graphql-go/compatibility-base/cmd"
 )
 
 func main() {
-	params := cmd.NewParams{}
+	handleErr := func(err error) {
+		log.Fatal(err)
+	}
+
+	params := cmd.NewParams{
+		Bubbletea: bubbletea.New(&bubbletea.Params{}),
+	}
 	cli := cmd.New(&params)
 
-	log.Println(cli)
+	result, err := cli.Run(&cmd.RunParams{})
+	if err != nil {
+		handleErr(err)
+	}
+
+	log.Println(result)
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/graphql-go/compatibility-base/bubbletea"
 	"github.com/graphql-go/compatibility-base/cmd"
+	"github.com/graphql-go/compatibility-base/config"
+	"github.com/graphql-go/compatibility-base/implementation"
 )
 
 func main() {
@@ -12,8 +14,18 @@ func main() {
 		log.Fatal(err)
 	}
 
+	cfg := config.New()
+	header := cfg.GraphqlJSImplementation.Repo.String(implementation.RefImplementationPrefix)
+
 	params := cmd.NewParams{
-		Bubbletea: bubbletea.New(&bubbletea.Params{}),
+		Bubbletea: bubbletea.New(&bubbletea.Params{
+			Model: bubbletea.NewChoicesModel(&bubbletea.ChoicesModelParams{
+				Choices: cfg.AvailableImplementations,
+				UI: bubbletea.ChoicesModelUIParams{
+					Header: header,
+				},
+			}),
+		}),
 	}
 	cli := cmd.New(&params)
 


### PR DESCRIPTION
#### Details
- `{bubbletea,cmd}`: adds code comments.
- `bubbletea`: updates code comments.
- `bubbletea`: syncs bubbletea pkg unit tests.
- `bubbletea`: adds ChoicesModelParams.Choice field.
- `bubbletea`: syncs tests to inner current Model.
- `bubbletea`: delegates BubbleTea methods to current model.
- `cmd`: syncs bubbletea cli run method.
- `bubbletea`: adds and wires Model interface.
- `main`: syncs bubbletea New function.
- `bubbletea`: consolidates Bubbletea and ChoicesModel structs.
- `main`: wires cmd CLI run method.
- `bubbletea`: adds BubbleTeaModel struct.
- `{go.mod,go.sum}`: adds github.com/charmbracelet/bubbles/table pkg.
- `bubbletea`: adds table BubbleTea field.
- `bin`: adds dev.sh script.
- `main`: adds initial structure.


#### Test Plan
- :heavy_check_mark:  Tested that the lib works as expected:
```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-base$ ./bin/dev.sh
┌───────────────────────────────────────────────────────────────────────────────────┐
│Reference Implementation: https://github.com/graphql/graphql-js/releases/tag/v0.6.0│
│(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1      │
│                                                                                   │
│                                                                                   │
│(press q to quit)                                                                  │
│                                                                                   │
└───────────────────────────────────────────────────────────────────────────────────┘
```