### PR TITLE
bubbletea: adds `TableModel` component scaffolding

### DIFF
--- a/bubbletea/tablemodel.go
+++ b/bubbletea/tablemodel.go
@@ -1,0 +1,84 @@
+package bubbletea
+
+import (
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// `TableModel` represents the component that implements the `Model` interface.
+type TableModel struct {
+	// table is the `bubbletea` table model.
+	table table.Model
+
+	// baseStyle is the base styling for the `table` model.
+	baseStyle lipgloss.Style
+}
+
+// `Init` is the `TableModel` method required for implementing the `Model` interface.
+// Initializes the `TableModel` component and returns a `bubbletea` command.
+func (tb TableModel) Init() tea.Cmd {
+	return nil
+}
+
+// `Update` is the `TableModel` method required for implementing the `Model` interface.
+// Updates the `TableModel` component, handles the given message updating the internal state.
+// Returns the current `TableModel` and the resolved command.
+func (tm TableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:golint,ireturn
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return tm, nil
+	}
+
+	switch keyMsg.String() {
+	case "ctrl+c", "q", "esc":
+		return tm, tea.Quit
+
+	case "enter":
+		return tm, tea.Quit
+
+	case "down", "j":
+		return tm, tea.Quit
+
+	case "up", "k":
+		return tm, tea.Quit
+	}
+
+	return tm, nil
+}
+
+// `View` is the `TableModel` method required for implementing the `Model` interface.
+// View renders the `TableModel` using the base style and returns the results.
+func (tm TableModel) View() string {
+	return tm.baseStyle.Render("") + "\n"
+}
+
+// `Run` is the `TableModel` method required for implementing the `Model` interface.
+// Runs the `TableModel` component and returns its result.
+func (tm TableModel) Run(model any) (any, error) {
+	result := &ChoicesModelResult{}
+
+	if m, ok := model.(TableModel); ok {
+		return m, nil
+	}
+
+	return result, nil
+}
+
+// `WithBaseStyle` updates the `TableModel` component to use the given base style.
+func (tm *TableModel) WithBaseStyle(baseStyle lipgloss.Style) {
+	tm.baseStyle = baseStyle
+}
+
+// `TableModelParams` represents the parameters component for the `NewTableModel` function.
+type TableModelParams struct {
+	// BaseStyle is the base styling parameter.
+	BaseStyle lipgloss.Style
+}
+
+// `NewTableModel` returns a pointer to a `TableModel`.
+func NewTableModel(p *TableModelParams) *TableModel {
+	return &TableModel{
+		baseStyle: p.BaseStyle,
+	}
+}

--- a/bubbletea/tablemodel.go
+++ b/bubbletea/tablemodel.go
@@ -9,6 +9,7 @@ import (
 // `TableModel` represents the component that implements the `Model` interface.
 type TableModel struct {
 	// table is the `bubbletea` table model.
+	// TODO(@chris-ramon): Wire to the `TableModel` component.
 	table table.Model
 
 	// baseStyle is the base styling for the `table` model.

--- a/bubbletea/tablemodel.go
+++ b/bubbletea/tablemodel.go
@@ -53,10 +53,14 @@ func (tm TableModel) View() string {
 	return tm.baseStyle.Render("") + "\n"
 }
 
+// `TableModelResult` represents the `TableModel` run method result.
+type TableModelResult struct {
+}
+
 // `Run` is the `TableModel` method required for implementing the `Model` interface.
 // Runs the `TableModel` component and returns its result.
 func (tm TableModel) Run(model any) (any, error) {
-	result := &ChoicesModelResult{}
+	result := &TableModelResult{}
 
 	if m, ok := model.(TableModel); ok {
 		return m, nil

--- a/bubbletea/tablemodel.go
+++ b/bubbletea/tablemodel.go
@@ -17,7 +17,7 @@ type TableModel struct {
 
 // `Init` is the `TableModel` method required for implementing the `Model` interface.
 // Initializes the `TableModel` component and returns a `bubbletea` command.
-func (tb TableModel) Init() tea.Cmd {
+func (tm TableModel) Init() tea.Cmd {
 	return nil
 }
 

--- a/bubbletea/tablemodel.go
+++ b/bubbletea/tablemodel.go
@@ -25,6 +25,7 @@ func (tm TableModel) Init() tea.Cmd {
 // `Update` is the `TableModel` method required for implementing the `Model` interface.
 // Updates the `TableModel` component, handles the given message updating the internal state.
 // Returns the current `TableModel` and the resolved command.
+// TODO(@chris-ramon): Implement the `tea.Msg` handlers.
 func (tm TableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:golint,ireturn
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {


### PR DESCRIPTION
#### Details
- `bubbletea`: adds `TableModel` component scaffolding.

#### Test Plan
- :heavy_check_mark:  Tested that the `TableModel` works as expected via `./bin/dev.sh`:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-base$ ./bin/dev.sh 
┌────────────────────────────────────────────────────────────────────────────────┐
│                                                                                │
│ Reference Implementation: https://github.com/graphql/graphql-                  │
│ js/releases/tag/v0.6.0                                                         │
│ (•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1  │
│                                                                                │
│                                                                                │
│ (press q to quit)                                                              │
│                                                                                │
└────────────────────────────────────────────────────────────────────────────────┘
2025/05/16 11:52:18 &{Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1
}
```


- :heavy_check_mark:  Tested that the `TableModel` works as expected via `./bin/test.sh`:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-base$ ./bin/test.sh .
?   	github.com/graphql-go/compatibility-base	[no test files]
?   	github.com/graphql-go/compatibility-base/assert	[no test files]
ok  	github.com/graphql-go/compatibility-base/bubbletea	0.004s
?   	github.com/graphql-go/compatibility-base/cmd	[no test files]
ok  	github.com/graphql-go/compatibility-base/config	0.001s
?   	github.com/graphql-go/compatibility-base/implementation	[no test files]
ok  	github.com/graphql-go/compatibility-base/puller	0.003s
?   	github.com/graphql-go/compatibility-base/types	[no test files]
```