### PR TITLE
`{main,bubbletea}`: adds support for multiple models and wires table model.

### DIFF
--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -68,8 +68,8 @@ func (b BubbleTea) Run() (any, error) {
 
 // Params represents the parameters for the `NewBubbleTea` function.
 type Params struct {
-	// Model is the model parameter of the BubbleTea component.
-	Model Model
+	// Models are the models parameters for the `BubbleTea` component.
+	Models Models
 
 	// BaseStyle is the base styling parameter of the BubbleTea component.
 	BaseStyle lipgloss.Style

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -32,6 +32,10 @@ type Model interface {
 type Models []Model
 
 func (m Models) First() Model {
+	if len(m) == 1 {
+		return m[0]
+	}
+
 	for _, model := range m {
 		if model.Order() == 1 {
 			return model

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -75,6 +75,7 @@ func (b BubbleTea) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		b.currentModel = nextModel
+		b.currentModel.WithBaseStyle(b.baseStyle)
 		return b, nil
 	default:
 		b.currentModel = model
@@ -131,7 +132,7 @@ func NewBaseStyle() lipgloss.Style {
 		Bold(false).
 		PaddingTop(1).
 		PaddingLeft(1).
-		Width(80)
+		Width(85)
 }
 
 // New returns a new BubbleTea struct instance.

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -61,7 +61,25 @@ func (b BubbleTea) Init() tea.Cmd {
 // Update is the `BubbleTea` method required for implementing the `Model` interface.
 func (b BubbleTea) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	model, cmd := b.currentModel.Update(msg)
-	b.currentModel = model
+
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return b, nil
+	}
+
+	switch keyMsg.String() {
+	case "enter":
+		nextModel := b.NextModel()
+		if nextModel == nil {
+			return b, cmd
+		}
+
+		b.currentModel = nextModel
+		return b, nil
+	default:
+		b.currentModel = model
+	}
+
 	return b, cmd
 }
 
@@ -80,6 +98,20 @@ func (b BubbleTea) Run() (any, error) {
 	}
 
 	return b.currentModel.Run(m)
+}
+
+// NextModel returns the next model, ordered by the order field.
+func (b BubbleTea) NextModel() Model {
+	currentOrder := b.currentModel.Order()
+	nextOrder := currentOrder + 1
+
+	for _, m := range b.models {
+		if m.Order() == nextOrder {
+			return m
+		}
+	}
+
+	return nil
 }
 
 // Params represents the parameters for the `NewBubbleTea` function.

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -25,6 +25,9 @@ type Model interface {
 	WithBaseStyle(baseStyle lipgloss.Style)
 }
 
+// Models are the slice of Model interfaces.
+type Models []Model
+
 // BubbleTea represents the CLI component that wraps the `bubbletea` library.
 type BubbleTea struct {
 	// baseStyle is the base styling of the BubbleTea component.

--- a/bubbletea/bubbletea.go
+++ b/bubbletea/bubbletea.go
@@ -23,10 +23,23 @@ type Model interface {
 
 	// WithBaseStyle updates the model to use the given base style.
 	WithBaseStyle(baseStyle lipgloss.Style)
+
+	// Order returns the order of the model.
+	Order() uint
 }
 
 // Models are the slice of Model interfaces.
 type Models []Model
+
+func (m Models) First() Model {
+	for _, model := range m {
+		if model.Order() == 1 {
+			return model
+		}
+	}
+
+	return nil
+}
 
 // BubbleTea represents the CLI component that wraps the `bubbletea` library.
 type BubbleTea struct {
@@ -35,6 +48,9 @@ type BubbleTea struct {
 
 	// currentModel is the current model of the BubbleTea component.
 	currentModel Model
+
+	// models are the models of the `BubbleTea` component.
+	models Models
 }
 
 // Init is the `BubbleTea` method required for implementing the `Model` interface.
@@ -91,7 +107,8 @@ func New(p *Params) *BubbleTea {
 	b := &BubbleTea{}
 
 	b.baseStyle = p.BaseStyle
-	b.currentModel = p.Model
+	b.models = p.Models
+	b.currentModel = p.Models.First()
 	b.currentModel.WithBaseStyle(p.BaseStyle)
 
 	return b

--- a/bubbletea/bubbletea_init_test.go
+++ b/bubbletea/bubbletea_init_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestBubbleTeaInit(t *testing.T) {
 	b := New(&Params{
-		Model: &ChoicesModel{},
+		Models:    Models{NewChoicesModel(&ChoicesModelParams{})},
+		BaseStyle: NewBaseStyle(),
 	})
 
 	assert.Nil(t, b.Init(), "unexpected non-nil result")

--- a/bubbletea/bubbletea_update_test.go
+++ b/bubbletea/bubbletea_update_test.go
@@ -20,12 +20,12 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles invalid tea key message",
 			initialBubbletea: New(&Params{
-				Model:     NewChoicesModel(&ChoicesModelParams{}),
+				Models:    Models{NewChoicesModel(&ChoicesModelParams{})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			updateParams: nil,
 			expectedModel: New(&Params{
-				Model:     NewChoicesModel(&ChoicesModelParams{}),
+				Models:    Models{NewChoicesModel(&ChoicesModelParams{})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			expectedCmd: (tea.Cmd)(nil),
@@ -33,14 +33,14 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles ctrl+c tea key message",
 			initialBubbletea: New(&Params{
-				Model:     NewChoicesModel(&ChoicesModelParams{}),
+				Models:    Models{NewChoicesModel(&ChoicesModelParams{})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			updateParams: tea.KeyMsg{
 				Type: tea.KeyCtrlC,
 			},
 			expectedModel: New(&Params{
-				Model:     NewChoicesModel(&ChoicesModelParams{}),
+				Models:    Models{NewChoicesModel(&ChoicesModelParams{})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			expectedCmd: tea.Quit,
@@ -48,21 +48,21 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles enter tea key message",
 			initialBubbletea: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Choices: []string{"test-choice-0"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			updateParams: tea.KeyMsg{
 				Type: tea.KeyEnter,
 			},
 			expectedModel: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Cursor:    0,
 					Choices:   []string{"test-choice-0"},
 					Choice:    "test-choice-0",
 					BaseStyle: NewBaseStyle(),
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			expectedCmd: tea.Quit,
@@ -70,9 +70,9 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles down tea key message",
 			initialBubbletea: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Choices: []string{"test-choice-0", "test-choice-1"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			updateParams: tea.KeyMsg{
@@ -80,10 +80,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Runes: []rune("j"),
 			},
 			expectedModel: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Cursor:  1,
 					Choices: []string{"test-choice-0", "test-choice-1"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			expectedCmd: nil,
@@ -91,10 +91,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles cursor reset for down tea key message",
 			initialBubbletea: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Cursor:  1,
 					Choices: []string{"test-choice-0", "test-choice-1"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			updateParams: tea.KeyMsg{
@@ -102,10 +102,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Runes: []rune("j"),
 			},
 			expectedModel: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Cursor:  0,
 					Choices: []string{"test-choice-0", "test-choice-1"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			expectedCmd: nil,
@@ -113,10 +113,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles up tea key message",
 			initialBubbletea: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Cursor:  1,
 					Choices: []string{"test-choice-0", "test-choice-1"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			updateParams: tea.KeyMsg{
@@ -124,10 +124,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Runes: []rune("k"),
 			},
 			expectedModel: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Cursor:  0,
 					Choices: []string{"test-choice-0", "test-choice-1"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			expectedCmd: nil,
@@ -135,10 +135,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 		{
 			subTestName: "Handles cursor reset for up tea key message",
 			initialBubbletea: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Cursor:  0,
 					Choices: []string{"test-choice-0"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			updateParams: tea.KeyMsg{
@@ -146,10 +146,10 @@ func TestBubbleTeaUpdate(t *testing.T) {
 				Runes: []rune("k"),
 			},
 			expectedModel: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Cursor:  0,
 					Choices: []string{"test-choice-0"},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
 			expectedCmd: nil,

--- a/bubbletea/bubbletea_view_test.go
+++ b/bubbletea/bubbletea_view_test.go
@@ -16,28 +16,28 @@ func TestBubbleTeaView(t *testing.T) {
 		{
 			subTestName: "Handles success view result",
 			initialBubbletea: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Choices: []string{"test-choice-0"},
 					UI: ChoicesModelUIParams{
 						Header: "test-header: \n",
 					},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
-			expectedView: "┌────────────────────────────────────────────────────────────────────────────────┐\n│                                                                                │\n│ test-header:                                                                   │\n│ (•) test-choice-0                                                              │\n│                                                                                │\n│ (press q to quit)                                                              │\n│                                                                                │\n└────────────────────────────────────────────────────────────────────────────────┘\n",
+			expectedView: "┌─────────────────────────────────────────────────────────────────────────────────────┐\n│                                                                                     │\n│ test-header:                                                                        │\n│ (•) test-choice-0                                                                   │\n│                                                                                     │\n│ (press q to quit)                                                                   │\n│                                                                                     │\n└─────────────────────────────────────────────────────────────────────────────────────┘\n",
 		},
 		{
 			subTestName: "Handles success view result with multiple choices",
 			initialBubbletea: New(&Params{
-				Model: NewChoicesModel(&ChoicesModelParams{
+				Models: Models{NewChoicesModel(&ChoicesModelParams{
 					Choices: []string{"test-choice-0", "test-choice-1"},
 					UI: ChoicesModelUIParams{
 						Header: "test-header: \n",
 					},
-				}),
+				})},
 				BaseStyle: NewBaseStyle(),
 			}),
-			expectedView: "┌────────────────────────────────────────────────────────────────────────────────┐\n│                                                                                │\n│ test-header:                                                                   │\n│ (•) test-choice-0                                                              │\n│ ( ) test-choice-1                                                              │\n│                                                                                │\n│ (press q to quit)                                                              │\n│                                                                                │\n└────────────────────────────────────────────────────────────────────────────────┘\n",
+			expectedView: "┌─────────────────────────────────────────────────────────────────────────────────────┐\n│                                                                                     │\n│ test-header:                                                                        │\n│ (•) test-choice-0                                                                   │\n│ ( ) test-choice-1                                                                   │\n│                                                                                     │\n│ (press q to quit)                                                                   │\n│                                                                                     │\n└─────────────────────────────────────────────────────────────────────────────────────┘\n",
 		},
 	}
 

--- a/bubbletea/choicesmodel.go
+++ b/bubbletea/choicesmodel.go
@@ -23,6 +23,9 @@ type ChoicesModel struct {
 
 	// baseStyle is the base styling of the BubbleTea component.
 	baseStyle lipgloss.Style
+
+	// order is the order of the model.
+	order uint
 }
 
 // ChoicesModelUI represents the UI struct for the `ChoicesModel` component.
@@ -118,6 +121,10 @@ func (b *ChoicesModel) WithBaseStyle(baseStyle lipgloss.Style) {
 	b.baseStyle = baseStyle
 }
 
+func (b *ChoicesModel) Order() uint {
+	return b.order
+}
+
 // ChoicesModelParams represents the parameters struct for the `NewChoicesModel` function.
 type ChoicesModelParams struct {
 	// Choice is the current CLI choice.
@@ -134,6 +141,9 @@ type ChoicesModelParams struct {
 
 	// BaseStyle is the base styling parameter of the BubbleTea component.
 	BaseStyle lipgloss.Style
+
+	// Order is the order parameter,
+	Order uint
 }
 
 // ChoicesModelUIParams represents the UI parameters for the `NewChoicesModel` function parameters.
@@ -152,5 +162,6 @@ func NewChoicesModel(p *ChoicesModelParams) *ChoicesModel {
 			header: p.UI.Header,
 		},
 		baseStyle: p.BaseStyle,
+		order:     p.Order,
 	}
 }

--- a/bubbletea/tablemodel.go
+++ b/bubbletea/tablemodel.go
@@ -96,8 +96,10 @@ func NewTableModel(p *TableModelParams) *TableModel {
 	columns := []table.Column{
 		{Title: "GitHub Stars", Width: 80},
 	}
+
+	// TODO(@chris-ramon): Wire external data.
 	rows := []table.Row{
-		{"9"},
+		{""},
 	}
 
 	t := table.New(

--- a/bubbletea/tablemodel.go
+++ b/bubbletea/tablemodel.go
@@ -14,6 +14,9 @@ type TableModel struct {
 	// table is the `bubbletea` table model.
 	// TODO(@chris-ramon): Wire to the `TableModel` component.
 	table table.Model
+
+	// order is the order of the model
+	order uint
 }
 
 // `Init` is the `TableModel` method required for implementing the `Model` interface.
@@ -26,7 +29,7 @@ func (tm TableModel) Init() tea.Cmd {
 // Updates the `TableModel` component, handles the given message updating the internal state.
 // Returns the current `TableModel` and the resolved command.
 // TODO(@chris-ramon): Implement the `tea.Msg` handlers.
-func (tm TableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:golint,ireturn
+func (tm *TableModel) Update(msg tea.Msg) (Model, tea.Cmd) { //nolint:golint,ireturn
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return tm, nil
@@ -76,10 +79,17 @@ func (tm *TableModel) WithBaseStyle(baseStyle lipgloss.Style) {
 	tm.baseStyle = baseStyle
 }
 
+func (tm *TableModel) Order() uint {
+	return tm.order
+}
+
 // `TableModelParams` represents the parameters component for the `NewTableModel` function.
 type TableModelParams struct {
 	// BaseStyle is the base styling parameter.
 	BaseStyle lipgloss.Style
+
+	// Order is the order parameter.
+	Order uint
 }
 
 // `NewTableModel` returns a pointer to a `TableModel`.
@@ -97,5 +107,6 @@ func NewTableModel(p *TableModelParams) *TableModel {
 	return &TableModel{
 		baseStyle: p.BaseStyle,
 		table:     t,
+		order:     p.Order,
 	}
 }

--- a/bubbletea/tablemodel.go
+++ b/bubbletea/tablemodel.go
@@ -12,7 +12,6 @@ type TableModel struct {
 	baseStyle lipgloss.Style
 
 	// table is the `bubbletea` table model.
-	// TODO(@chris-ramon): Wire to the `TableModel` component.
 	table table.Model
 
 	// order is the order of the model
@@ -55,7 +54,7 @@ func (tm *TableModel) Update(msg tea.Msg) (Model, tea.Cmd) { //nolint:golint,ire
 // `View` is the `TableModel` method required for implementing the `Model` interface.
 // View renders the `TableModel` using the base style and returns the results.
 func (tm TableModel) View() string {
-	return tm.baseStyle.Render("") + "\n"
+	return tm.baseStyle.Render(tm.table.View()) + "\n"
 }
 
 // `TableModelResult` represents the `TableModel` run method result.
@@ -94,15 +93,34 @@ type TableModelParams struct {
 
 // `NewTableModel` returns a pointer to a `TableModel`.
 func NewTableModel(p *TableModelParams) *TableModel {
-	columns := []table.Column{}
-	rows := []table.Row{}
+	columns := []table.Column{
+		{Title: "GitHub Stars", Width: 80},
+	}
+	rows := []table.Row{
+		{"9"},
+	}
 
 	t := table.New(
 		table.WithColumns(columns),
 		table.WithRows(rows),
-		table.WithFocused(true),
-		table.WithHeight(7),
+		table.WithFocused(false),
+		table.WithHeight(2),
 	)
+
+	s := table.DefaultStyles()
+
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		BorderBottom(true).
+		Bold(false)
+
+	s.Selected = s.Selected.
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("#a8a7a3")).
+		Bold(false)
+
+	t.SetStyles(s)
 
 	return &TableModel{
 		baseStyle: p.BaseStyle,

--- a/main.go
+++ b/main.go
@@ -27,6 +27,9 @@ func main() {
 						Header: header,
 					},
 				}),
+				bubbletea.NewTableModel(&bubbletea.TableModelParams{
+					Order: 2,
+				}),
 			},
 			BaseStyle: bubbletea.NewBaseStyle(),
 		}),

--- a/main.go
+++ b/main.go
@@ -19,12 +19,15 @@ func main() {
 
 	params := cmd.NewParams{
 		Bubbletea: bubbletea.New(&bubbletea.Params{
-			Model: bubbletea.NewChoicesModel(&bubbletea.ChoicesModelParams{
-				Choices: cfg.AvailableImplementations,
-				UI: bubbletea.ChoicesModelUIParams{
-					Header: header,
-				},
-			}),
+			Models: bubbletea.Models{
+				bubbletea.NewChoicesModel(&bubbletea.ChoicesModelParams{
+					Order:   1,
+					Choices: cfg.AvailableImplementations,
+					UI: bubbletea.ChoicesModelUIParams{
+						Header: header,
+					},
+				}),
+			},
 			BaseStyle: bubbletea.NewBaseStyle(),
 		}),
 	}


### PR DESCRIPTION
#### Details
- `bubbletea`: syncs unit tests.
- `bubbletea/tablemodel`: adds table data TODO.
- `bubbletea`: adds defaults to Models.First.
- `bubbletea`: wires table styles & rendering.
- `bubbletea`: improves current model styling.
- `bubbletea`: adds support for next model.
- `main`: wires TableModel.
- `bubbletea/tablemodel`: adds order support.
- `main`: wires bubbletea.Models.
- `bubbletea`: wires order to ChoicesModel.
- `bubbletea`: adds Models support.
- `bubbletea`: improves Params.Models code comment.
- `bubbletea`: adds Models type.

#### Test Plan
:heavy_check_mark: Tested that the `CLI` works as expected via `./bin/dev.sh`:
```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-base$ ./bin/dev.sh 
┌─────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                     │
│ Reference Implementation: https://github.com/graphql/graphql-js/releases/tag/v0.6.0 │
│ (•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1       │
│                                                                                     │
│                                                                                     │
│ (press q to quit)                                                                   │
│                                                                                     │
└─────────────────────────────────────────────────────────────────────────────────────┘
```

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-base$ ./bin/dev.sh 
┌─────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                     │
│  GitHub Stars                                                                       │
│ ──────────────────────────────────────────────────────────────────────────────────  │
│                                                                                     │
└─────────────────────────────────────────────────────────────────────────────────────┘

```


:heavy_check_mark: Tested that the `CLI` works as expected via `./bin/test.sh`:
```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-base$ ./bin/test.sh 
?   	github.com/graphql-go/compatibility-base	[no test files]
?   	github.com/graphql-go/compatibility-base/assert	[no test files]
ok  	github.com/graphql-go/compatibility-base/bubbletea	0.004s
?   	github.com/graphql-go/compatibility-base/cmd	[no test files]
ok  	github.com/graphql-go/compatibility-base/config	0.002s
?   	github.com/graphql-go/compatibility-base/implementation	[no test files]
ok  	github.com/graphql-go/compatibility-base/puller	0.004s
?   	github.com/graphql-go/compatibility-base/types	[no test files]
```
